### PR TITLE
fix: re-sign binary after patching on macOS to prevent Gatekeeper kill

### DIFF
--- a/patch-cli-claude-code.js
+++ b/patch-cli-claude-code.js
@@ -309,6 +309,17 @@ if (require.main === module) {
     const finalPath = outputPath || targetPath;
     fs.writeFileSync(finalPath, result.content, 'latin1');
     console.log(`Success: Claude has been patched at ${finalPath}`);
+
+    // Re-sign binary after patching (required on macOS to pass Gatekeeper)
+    if (os.platform() === 'darwin' && !finalPath.endsWith('.js')) {
+        try {
+            execSync(`codesign --sign - --force --preserve-metadata=entitlements,requirements,flags "${finalPath}"`, { stdio: 'inherit' });
+            console.log('Re-signed binary successfully.');
+        } catch (e) {
+            console.error('Warning: Re-sign failed:', e.message);
+            console.error(`Run manually: codesign --sign - --force --preserve-metadata=entitlements,requirements,flags "${finalPath}"`);
+        }
+    }
 }
 
 // Export for testing


### PR DESCRIPTION
## Problem

After `patch-cli-claude-code.js` patches the Claude Code binary for Vietnamese IME (Telex/VNI input), the binary's codesign signature becomes invalid. macOS Gatekeeper then kills the process immediately on launch with `killed`.

This is especially painful after Claude Code auto-updates — the new binary gets patched but not re-signed, so Claude becomes unusable until manually re-signed.

Fixes #2

## Solution

Automatically run `codesign --sign -` right after writing the patched binary, but only on macOS (`darwin`) and only for non-`.js` output files.

```javascript
// Re-sign binary after patching (required on macOS to pass Gatekeeper)
if (os.platform() === 'darwin' && !finalPath.endsWith('.js')) {
    try {
        execSync(`codesign --sign - --force --preserve-metadata=entitlements,requirements,flags "${finalPath}"`, { stdio: 'inherit' });
        console.log('Re-signed binary successfully.');
    } catch (e) {
        console.error('Warning: Re-sign failed:', e.message);
        console.error(`Run manually: codesign --sign - --force --preserve-metadata=entitlements,requirements,flags "${finalPath}"`);
    }
}
```

- Uses `os.platform()` — no-op on Linux/Windows
- Uses ad-hoc signing (`--sign -`) — no Apple Developer certificate required
- Fails gracefully with a manual fallback command if `codesign` is unavailable