### PR TITLE
fix: prefer cli.js and detect Bun-bytecode native binaries

### DIFF
--- a/patch-cli-claude-code.js
+++ b/patch-cli-claude-code.js
@@ -26,6 +26,7 @@ Description:
 
 function findClaudePath() {
     const isWin = os.platform() === "win32";
+    const home = process.env.HOME || process.env.USERPROFILE || "";
 
     const run = (cmd) => {
         try {
@@ -40,7 +41,84 @@ function findClaudePath() {
 
     const exists = (p) => p && fs.existsSync(p);
 
-    // 1) which / where / bun which
+    // Helper: build the list of @anthropic-ai/claude-code/cli.js candidates
+    // across common install locations. We prefer cli.js over native binaries
+    // because recent native builds (>=2.1.108) are compiled to Bun bytecode
+    // and cannot be patched via text matching.
+    const jsCandidates = [];
+    const addJs = (...parts) => {
+        if (parts.every(Boolean)) {
+            jsCandidates.push(
+              path.join(...parts, "@anthropic-ai", "claude-code", "cli.js")
+            );
+        }
+    };
+
+    // Official Claude Code local installer (`claude migrate-installer`)
+    if (home) {
+        addJs(home, ".claude", "local", "node_modules");
+    }
+
+    // Bun global install
+    const bunInstall =
+      process.env.BUN_INSTALL ||
+      (home ? path.join(home, ".bun") : "");
+    if (bunInstall) {
+        addJs(bunInstall, "install", "global", "node_modules");
+    }
+
+    // npm global (ask npm first)
+    try {
+        const npmRoot = execSync("npm root -g", { stdio: ["ignore", "pipe", "ignore"] })
+          .toString()
+          .trim();
+        if (npmRoot) addJs(npmRoot);
+    } catch (e) { /* npm not available */ }
+
+    // yarn / pnpm global
+    for (const cmd of ["yarn global dir", "pnpm root -g"]) {
+        const p = run(cmd);
+        if (p) addJs(p);
+    }
+
+    // Windows-specific fallbacks
+    if (isWin) {
+        addJs(process.env.APPDATA, "npm", "node_modules");
+        addJs(process.env.LOCALAPPDATA, "npm", "node_modules");
+
+        if (process.env.NVM_HOME) {
+            try {
+                for (const d of fs.readdirSync(process.env.NVM_HOME)) {
+                    addJs(process.env.NVM_HOME, d, "node_modules");
+                }
+            } catch (e) { /* ignore */ }
+        }
+        // Scoop
+        if (process.env.SCOOP) {
+            addJs(process.env.SCOOP, "persist", "nodejs", "bin", "node_modules");
+        }
+    } else {
+        // Unix: nvm versions
+        if (process.env.NVM_DIR) {
+            try {
+                const versionsDir = path.join(process.env.NVM_DIR, "versions", "node");
+                if (fs.existsSync(versionsDir)) {
+                    for (const d of fs.readdirSync(versionsDir)) {
+                        addJs(versionsDir, d, "lib", "node_modules");
+                    }
+                }
+            } catch (e) { /* ignore */ }
+        }
+        // Homebrew
+        addJs("/opt/homebrew/lib/node_modules");
+        addJs("/usr/local/lib/node_modules");
+    }
+
+    for (const p of jsCandidates) {
+        if (exists(p)) return p;
+    }
+
+    // No cli.js found -> fall back to native binary via PATH lookup
     for (const cmd of [
         isWin ? "where claude" : "which claude",
         "bun which claude",
@@ -49,107 +127,29 @@ function findClaudePath() {
         if (exists(p)) {
             if (!isWin) {
                 try {
-                    return execSync(`realpath "${ p }"`).toString().trim();
-                } catch {}
+                    const real = execSync(`realpath "${p}"`).toString().trim();
+                    if (exists(real)) return real;
+                } catch { /* ignore */ }
             }
             return p;
         }
     }
 
-    // 2) Bun global paths
-    const bunInstall =
-      process.env.BUN_INSTALL ||
-      (isWin
-        ? path.join(process.env.USERPROFILE || "", ".bun")
-        : path.join(process.env.HOME || "", ".bun"));
-
-    const bunPaths = [
-        path.join(bunInstall, "bin", isWin ? "claude.exe" : "claude"),
-        path.join(bunInstall, "bin", isWin ? "claude.cmd" : "claude"),
-        path.join(
-          bunInstall,
-          "install",
-          "global",
-          "node_modules",
-          "@anthropic-ai",
-          "claude-code",
-          "cli.js"
-        ),
-    ];
-
-    for (const p of bunPaths) {
-        if (exists(p)) {
-            return p;
+    // Native binary directly in bun/claude install dir
+    if (bunInstall) {
+        for (const bin of [
+            path.join(bunInstall, "bin", isWin ? "claude.exe" : "claude"),
+            path.join(bunInstall, "bin", isWin ? "claude.cmd" : "claude"),
+        ]) {
+            if (exists(bin)) return bin;
         }
     }
 
-    // 3) npm global
-    try {
-        const npmRoot = execSync("npm root -g").toString().trim();
-
-        const cliPath = path.join(
-          npmRoot,
-          "@anthropic-ai",
-          "claude-code",
-          "cli.js"
-        );
-        if (exists(cliPath)) {
-
-            return cliPath;
-        }
-    } catch (e) {
-
+    // Claude Code native installer default location (~/.local/bin/claude[.exe])
+    if (home) {
+        const nativeBin = path.join(home, ".local", "bin", isWin ? "claude.exe" : "claude");
+        if (exists(nativeBin)) return nativeBin;
     }
-
-    // 4) Windows fallbacks
-    if (isWin) {
-
-        const paths = [
-            path.join(
-              process.env.APPDATA || "",
-              "npm",
-              "node_modules",
-              "@anthropic-ai",
-              "claude-code",
-              "cli.js"
-            ),
-            path.join(
-              process.env.LOCALAPPDATA || "",
-              "npm",
-              "node_modules",
-              "@anthropic-ai",
-              "claude-code",
-              "cli.js"
-            ),
-        ];
-
-        if (process.env.NVM_HOME) {
-            try {
-                for (const d of fs.readdirSync(process.env.NVM_HOME)) {
-                    paths.push(
-                      path.join(
-                        process.env.NVM_HOME,
-                        d,
-                        "node_modules",
-                        "@anthropic-ai",
-                        "claude-code",
-                        "cli.js"
-                      )
-                    );
-                }
-            } catch (e) {
-
-            }
-        }
-
-        for (const p of paths) {
-            if (exists(p)) {
-
-                return p;
-            }
-        }
-    }
-
 
     return null;
 }
@@ -214,6 +214,16 @@ ${m2}`.replace(/^\s+/gm, '');
     });
 
     if (matches.length === 0) {
+        // Starting from Claude Code v2.1.108, the native binary bundles the
+        // main module as Bun bytecode, so the JS source text is no longer
+        // present and cannot be patched. Detect that and surface a clear
+        // error so users know to switch to the npm-installed cli.js.
+        if (binaryContent.includes('// @bun @bytecode')) {
+            return {
+                success: false,
+                message: 'Patch failed: this native binary is compiled to Bun bytecode (Claude Code >= 2.1.108) and cannot be patched as text. Install the npm version and re-run:\n  npm install -g @anthropic-ai/claude-code\n  npx fix-vietnamese-claude-code'
+            };
+        }
         return { success: false, message: 'Patch failed: no match found' };
     }
 


### PR DESCRIPTION
## Summary

- `findClaudePath()` now prefers `cli.js` from common package-manager install locations (npm/yarn/pnpm global, nvm, bun, scoop, Homebrew, `~/.claude/local/`) **before** falling back to the native `claude` binary on `PATH`. Previously on Windows, `where claude` returned `C:\Users\<user>\.local\bin\claude.exe` (the Claude Code native installer), even when a patchable `cli.js` was already installed via npm, causing the script to attempt (and fail) to patch the binary.
- `patchContentBinary()` detects the `// @bun @bytecode` pragma that Claude Code >= 2.1.108 emits in native builds and surfaces a clear error instructing the user to install the npm version, instead of the opaque "Patch failed: no match found".

## Motivation

On the native installer (`~/.local/bin/claude.exe`), `npx fix-vietnamese-claude-code` always fails today:
- On versions <= 2.1.107 the tool could still patch the binary, but only if `findClaudePath()` happened to resolve the right file; when a user had the npm cli.js installed alongside, the native `.exe` was still preferred.
- On versions >= 2.1.108 the main module is bundled as Bun bytecode, so text-based patching can no longer succeed on the native binary at all. Users need to switch to the npm-installed `cli.js` — which this PR now guides them to, and also auto-detects.

## Test plan

- [x] Existing vitest suite still passes on patchable versions:
  - `ONLY_PLATFORM=win32-x64 ONLY_VERSION=2.1.100,2.1.107 npx vitest run` — binary patch: **pass**
  - `ONLY_PLATFORM=js ONLY_VERSION=2.1.100,2.1.107 npx vitest run` — JS patch: **pass**
- [x] Running the CLI against a v2.1.112 native binary now prints a helpful bytecode-detected error instead of "no match found".
- [x] Running the CLI with no `-f` flag on a system that has both native `.exe` and npm `cli.js` installed now auto-selects the npm `cli.js`.

> Note: JS/binary patching itself for Claude Code >= 2.1.108 remains out of scope — the regex pattern is also outdated upstream. This PR focuses on correct file resolution and clearer errors.