### PR TITLE
fix: prefer cli.js and detect Bun-bytecode native binaries (#5)

### DIFF
--- a/patch-cli-claude-code.js
+++ b/patch-cli-claude-code.js
@@ -26,6 +26,7 @@ Description:
 
 function findClaudePath() {
     const isWin = os.platform() === "win32";
+    const home = process.env.HOME || process.env.USERPROFILE || "";
 
     const run = (cmd) => {
         try {
@@ -40,7 +41,89 @@ function findClaudePath() {
 
     const exists = (p) => p && fs.existsSync(p);
 
-    // 1) which / where / bun which
+    // Build candidate paths for @anthropic-ai/claude-code/cli.js across the
+    // common install locations. We prefer cli.js over the native binary
+    // because recent native builds (Claude Code >= 2.1.108) bundle the main
+    // module as Bun bytecode and cannot be patched via text matching.
+    const jsCandidates = [];
+    const addJs = (...parts) => {
+        if (parts.every(Boolean)) {
+            jsCandidates.push(
+              path.join(...parts, "@anthropic-ai", "claude-code", "cli.js")
+            );
+        }
+    };
+
+    // Official Claude Code local installer (`claude migrate-installer`)
+    if (home) {
+        addJs(home, ".claude", "local", "node_modules");
+    }
+
+    // Bun global install
+    const bunInstall =
+      process.env.BUN_INSTALL ||
+      (home ? path.join(home, ".bun") : "");
+    if (bunInstall) {
+        addJs(bunInstall, "install", "global", "node_modules");
+    }
+
+    // npm global
+    const npmRoot = run("npm root -g");
+    if (npmRoot) addJs(npmRoot);
+
+    // yarn global: `yarn global dir` returns the prefix dir; packages live
+    // under its node_modules/ subfolder (unless the output already ends with
+    // node_modules on some yarn versions).
+    const yarnGlobalDir = run("yarn global dir");
+    if (yarnGlobalDir) {
+        const yarnNodeModules = path.basename(yarnGlobalDir) === "node_modules"
+          ? yarnGlobalDir
+          : path.join(yarnGlobalDir, "node_modules");
+        addJs(yarnNodeModules);
+    }
+
+    // pnpm global
+    const pnpmRoot = run("pnpm root -g");
+    if (pnpmRoot) addJs(pnpmRoot);
+
+    // Windows-specific fallbacks
+    if (isWin) {
+        addJs(process.env.APPDATA, "npm", "node_modules");
+        addJs(process.env.LOCALAPPDATA, "npm", "node_modules");
+
+        if (process.env.NVM_HOME) {
+            try {
+                for (const d of fs.readdirSync(process.env.NVM_HOME)) {
+                    addJs(process.env.NVM_HOME, d, "node_modules");
+                }
+            } catch (e) { /* ignore */ }
+        }
+        // Scoop
+        if (process.env.SCOOP) {
+            addJs(process.env.SCOOP, "persist", "nodejs", "bin", "node_modules");
+        }
+    } else {
+        // Unix: nvm versions
+        if (process.env.NVM_DIR) {
+            try {
+                const versionsDir = path.join(process.env.NVM_DIR, "versions", "node");
+                if (fs.existsSync(versionsDir)) {
+                    for (const d of fs.readdirSync(versionsDir)) {
+                        addJs(versionsDir, d, "lib", "node_modules");
+                    }
+                }
+            } catch (e) { /* ignore */ }
+        }
+        // Homebrew
+        addJs("/opt/homebrew/lib/node_modules");
+        addJs("/usr/local/lib/node_modules");
+    }
+
+    for (const p of jsCandidates) {
+        if (exists(p)) return p;
+    }
+
+    // No cli.js found -> fall back to native binary via PATH lookup
     for (const cmd of [
         isWin ? "where claude" : "which claude",
         "bun which claude",
@@ -49,107 +132,31 @@ function findClaudePath() {
         if (exists(p)) {
             if (!isWin) {
                 try {
-                    return execSync(`realpath "${ p }"`).toString().trim();
-                } catch {}
+                    const real = fs.realpathSync.native
+                      ? fs.realpathSync.native(p)
+                      : fs.realpathSync(p);
+                    if (exists(real)) return real;
+                } catch { /* ignore */ }
             }
             return p;
         }
     }
 
-    // 2) Bun global paths
-    const bunInstall =
-      process.env.BUN_INSTALL ||
-      (isWin
-        ? path.join(process.env.USERPROFILE || "", ".bun")
-        : path.join(process.env.HOME || "", ".bun"));
-
-    const bunPaths = [
-        path.join(bunInstall, "bin", isWin ? "claude.exe" : "claude"),
-        path.join(bunInstall, "bin", isWin ? "claude.cmd" : "claude"),
-        path.join(
-          bunInstall,
-          "install",
-          "global",
-          "node_modules",
-          "@anthropic-ai",
-          "claude-code",
-          "cli.js"
-        ),
-    ];
-
-    for (const p of bunPaths) {
-        if (exists(p)) {
-            return p;
+    // Native binary directly in bun install dir
+    if (bunInstall) {
+        for (const bin of [
+            path.join(bunInstall, "bin", isWin ? "claude.exe" : "claude"),
+            path.join(bunInstall, "bin", isWin ? "claude.cmd" : "claude"),
+        ]) {
+            if (exists(bin)) return bin;
         }
     }
 
-    // 3) npm global
-    try {
-        const npmRoot = execSync("npm root -g").toString().trim();
-
-        const cliPath = path.join(
-          npmRoot,
-          "@anthropic-ai",
-          "claude-code",
-          "cli.js"
-        );
-        if (exists(cliPath)) {
-
-            return cliPath;
-        }
-    } catch (e) {
-
+    // Claude Code native installer default location (~/.local/bin/claude[.exe])
+    if (home) {
+        const nativeBin = path.join(home, ".local", "bin", isWin ? "claude.exe" : "claude");
+        if (exists(nativeBin)) return nativeBin;
     }
-
-    // 4) Windows fallbacks
-    if (isWin) {
-
-        const paths = [
-            path.join(
-              process.env.APPDATA || "",
-              "npm",
-              "node_modules",
-              "@anthropic-ai",
-              "claude-code",
-              "cli.js"
-            ),
-            path.join(
-              process.env.LOCALAPPDATA || "",
-              "npm",
-              "node_modules",
-              "@anthropic-ai",
-              "claude-code",
-              "cli.js"
-            ),
-        ];
-
-        if (process.env.NVM_HOME) {
-            try {
-                for (const d of fs.readdirSync(process.env.NVM_HOME)) {
-                    paths.push(
-                      path.join(
-                        process.env.NVM_HOME,
-                        d,
-                        "node_modules",
-                        "@anthropic-ai",
-                        "claude-code",
-                        "cli.js"
-                      )
-                    );
-                }
-            } catch (e) {
-
-            }
-        }
-
-        for (const p of paths) {
-            if (exists(p)) {
-
-                return p;
-            }
-        }
-    }
-
 
     return null;
 }
@@ -214,6 +221,17 @@ ${m2}`.replace(/^\s+/gm, '');
     });
 
     if (matches.length === 0) {
+        // Starting from Claude Code v2.1.108, the native binary bundles the
+        // main module as Bun bytecode, so the JS source text is no longer
+        // present and cannot be patched. Detect that and guide the user to
+        // install the npm version (this tool will auto-detect its cli.js
+        // on the next run).
+        if (binaryContent.includes('// @bun @bytecode')) {
+            return {
+                success: false,
+                message: 'Patch failed: this native binary is compiled to Bun bytecode (Claude Code >= 2.1.108) and cannot be patched as text.\nInstall the npm version and re-run this tool (it will auto-detect the installed cli.js):\n  npm install -g @anthropic-ai/claude-code\n  npx fix-vietnamese-claude-code'
+            };
+        }
         return { success: false, message: 'Patch failed: no match found' };
     }
 


### PR DESCRIPTION
Fixes #5.

## Summary

- `findClaudePath()` now searches common `@anthropic-ai/claude-code/cli.js` locations (npm/yarn/pnpm global, bun, nvm, scoop, Homebrew, `~/.claude/local/`) **before** falling back to the native `claude` binary on `PATH`. On Windows, `where claude` returns the native installer's `~/.local/bin/claude.exe` even when a patchable cli.js is available, so preferring cli.js fixes the common failure mode reported in #5.
- `patchContentBinary()` detects the `// @bun @bytecode` pragma used in Claude Code >= 2.1.108 native builds and returns a clear, actionable error pointing users at `npm install -g @anthropic-ai/claude-code`. Users no longer see the opaque `Patch failed: no match found`.

## Repro for issue #5

```text
> install.cmd 2.1.112
  Location: C:\Users\<user>\.local\bin\claude.exe

> npx fix-vietnamese-claude-code
Target: C:\Users\<user>\.local\bin\claude.exe
Patch failed: no match found         <-- unhelpful
```

After this PR:

```text
> npx fix-vietnamese-claude-code
Target: C:\Users\<user>\.local\bin\claude.exe
Patch failed: this native binary is compiled to Bun bytecode (Claude Code >= 2.1.108) and cannot be patched as text.
Install the npm version and re-run this tool (it will auto-detect the installed cli.js):
  npm install -g @anthropic-ai/claude-code
  npx fix-vietnamese-claude-code
```

Running the follow-up `npm install -g @anthropic-ai/claude-code` then `npx fix-vietnamese-claude-code` auto-finds the installed `cli.js` (previously the binary on `PATH` would still win the lookup).

## Additional notes

- `yarn global dir` output is normalized to its `node_modules/` subfolder so yarn-installed packages actually resolve.
- `realpath` symlink resolution now uses `fs.realpathSync` instead of shelling out (safer + portable to systems without a `realpath` binary).

> Note: patching itself for Claude Code >= 2.1.108 remains out of scope — the existing regex pattern no longer matches the upstream source on those versions even in the npm cli.js build. This PR focuses on correct file resolution and a clear error path, which is what #5 actually hits first.

## Test plan

- [x] `ONLY_PLATFORM=win32-x64 ONLY_VERSION=2.1.100,2.1.107 npx vitest run` — binary patch: **pass**
- [x] `ONLY_PLATFORM=js ONLY_VERSION=2.1.100,2.1.107 npx vitest run` — JS patch: **pass**
- [x] Running the CLI against a v2.1.112 native binary prints the new bytecode-detected error.
- [x] With both native `.exe` and npm `cli.js` installed, the CLI auto-selects the npm `cli.js`.